### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/qt-fsarchiver/src/clone.cpp
+++ b/qt-fsarchiver/src/clone.cpp
@@ -706,6 +706,8 @@ int DialogClone::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 void DialogClone::rdbutton_clone(){

--- a/qt-fsarchiver/src/dir.cpp
+++ b/qt-fsarchiver/src/dir.cpp
@@ -809,6 +809,8 @@ int DialogDIR::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 void DialogDIR::chkhidden(){

--- a/qt-fsarchiver/src/mainWindow.cpp
+++ b/qt-fsarchiver/src/mainWindow.cpp
@@ -1246,6 +1246,8 @@ int MWindow::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 
@@ -1786,6 +1788,7 @@ int found;
              	zahl_.replace(found, 1, ","); 
             return zahl_  + tr(" GB");
 	 }   
+   return zahl_;
 }
 
 

--- a/qt-fsarchiver/src/mbr.cpp
+++ b/qt-fsarchiver/src/mbr.cpp
@@ -477,6 +477,8 @@ int DialogMBR::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 QString DialogMBR::mtab_einlesen(QString partition_if_home)

--- a/qt-fsarchiver/src/net.cpp
+++ b/qt-fsarchiver/src/net.cpp
@@ -1592,6 +1592,8 @@ int DialogNet::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 void DialogNet::esc_end()
@@ -1713,6 +1715,8 @@ int i = 0;
          }
         if (i == 0)
            mountflag = 1; //Beim erfolgreichen mounten wird das erneute mounten verhindert
+
+    return 0;
 }
 
 

--- a/qt-fsarchiver/src/net_ein.cpp
+++ b/qt-fsarchiver/src/net_ein.cpp
@@ -453,7 +453,7 @@ QString NetEin::user_holen()
   return user_net_ein;
 }
 
-int NetEin:: end()
+void NetEin:: end()
 { 
    close();
 }
@@ -686,6 +686,8 @@ int NetEin::questionMessage(QString frage)
     		return 1;
 	else if (msg.clickedButton() == noButton)
     		return 2;
+
+  return 0;
 }
 
 

--- a/qt-fsarchiver/src/net_ein.h
+++ b/qt-fsarchiver/src/net_ein.h
@@ -54,7 +54,7 @@ private:
 	QFileSystemModel *dirModel;
 	
 private slots:
-	int end();
+	void end();
         int go();
 };
 


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.