### PR TITLE
Update qt-fsarchiver.desktop

### DIFF
--- a/qt-fsarchiver/starter/qt-fsarchiver.desktop
+++ b/qt-fsarchiver/starter/qt-fsarchiver.desktop
@@ -7,4 +7,5 @@ Icon=/usr/share/app-install/icons/harddrive2.png
 Terminal=false
 Type=Application
 StartupNotify=true
+Categories=System;
 


### PR DESCRIPTION
local Gentoo patch , Categories=System; 
adds to xfce4 in system menu , and or other display managers. 
adds to correct path ie like woeusb launcher ..  (and swiped snippet from)